### PR TITLE
Review of remixer vocabulary ideas

### DIFF
--- a/notes/NiN-remixer-vocab-ideas.txt
+++ b/notes/NiN-remixer-vocab-ideas.txt
@@ -1,23 +1,84 @@
+((Suggest renaming this file to .md, so that GitHub will render the markdown.))
+
 # Notes on vocabulary choices
 
-Going through the various parts of the architecture diagram:
+Going through the various parts of the [architecture diagram](https://github.com/oerc-music/nin-remixer-public/blob/master/notes/Architecture.svg):
 
-Fragments from NiN:
-  What is called a "DMO"
-  Music Ontology to reference the score as MEI
-  PROV for the "provenance metadata"
-  Probably local vocab for the specifics of the metadata
+----
+
+## Fragments from NiN:
+
+- What is called a "DMO"
+
+((GK:side-point: I'd be inclined to avoid talking about DMOs for now - Kevin has often indicated that he views DMOs as being possibly emergent from this work, rather than designed in.))
+
+- Music Ontology to reference the score as MEI
+
+((The MELD Climb! modeling I did for MELD has this also linked to FRBR: see "Score for segment for stage" in https://github.com/gklyne/MELD_Climb_performance/blob/master/20171122-MELD-modelling-climb.svg))
+
+- PROV for the "provenance metadata"
+
+((GK: I assume this is as exported by NiN?))
+
+- Probably local vocab for the specifics of the metadata
   (still need to map this)
 
-Matched Fragments:
-  Represent matches as annotations
-  Some kinds of match can be recorded by relating two fragments to a shared concept
-    the "compatible key" match is probably included
-    there are concepts in the Chord Ontology (http://purl.org/ontology/chord/) which relate to the scales and could be useful
-    there is also a Keys Ontology refered to by Music Ontology (http://purl.org/NET/c4dm/keys.owl)
-  Other kinds of match may need need to be a pairwise 
-    in which case only make sense within a "working set"
-    (a consideration for the Architecture)
+((GK: Yes - I would suggest inventing something for now, then reviewing and seeing if it can be replaced by or related to any existing vocab))
+
+((GK: I think next step here is to add a diagram and/or example that shows how the vocab parts fit together.))
+
+((GK: I think we also need to figure out how the NiN Provides these to the Remixer - I like the idea of using an LDP container based on an existing LDP implementation; rather like using a file sytem to communicate between applications on a computer.  Then to clarify the full representation of a fragment, which I would expect a mixture of LD and other media resources))
+
+----
+
+## Matched Fragments:
+
+- Represent matches as annotations
+- Some kinds of match can be recorded by relating two fragments to a shared concept
+    - the "compatible key" match is probably included
+    - there are concepts in the Chord Ontology (http://purl.org/ontology/chord/) which relate to the scales and could be useful
+    - there is also a Keys Ontology refered to by Music Ontology (http://purl.org/NET/c4dm/keys.owl)
+- Other kinds of match may need need to be a pairwise 
+    - in which case only make sense within a "working set" (a consideration for the Architecture)
+
+((GK: I think this should be developed separately as a match architecture document, and then come back and add vocabulary details.  I'll add some thoughts below in this document, but suggest that anything adopted should be moved to a separate doc.))
+
+The NiN remixer needs to be able to access fragment match candidates based on a number of criteria:
+
+- match criteria (e.g. deduced key signature(s), rhythmic style, etc.)
+- the current state of the work being assembled 
+- selected position ("cursor") or elements in the work under construction
+- the role of the offered candidates (e.g. following item befiore cursor, preceding item after cursor, fitting between predecessor and successor at cursor, etc)
+- the extent of the insert required; e.g. single fragment, multiple fragment, etc.
+
+Not all of these criteria are necessarily resolved by the compatibility service itself.  I would initially propose an interface that indicates that uses:
+
+1. a desgnated fragment
+2. a compatibility model
+3. a match-before or match-after indicator
+
+I would imagine the remixer itself would be able to use this to assemble longer sequences and/ior satisfy multiple criteria.
+
+A (partial?) REST-style interface for this could look something like:
+
+- a URI that embodies compatibility model and target fragment used to retrieve a list of candiate fragments (@@detail TBD, but I'm thinking of an LDP container per compatibility model (possibly simplified as GET-only))
+- candidate fragments returned as Web Annotation(s) that
+    - target the indicated fragment
+    - have a body that describes a candidate match (@@details TBD), including a reference to the matching fragment and any qualifying information (e.g. match before, match after, etc.)
+    - a motivation that indicates the annotation designates a match
+    - provenance about how the match was determined (personal annotaton, algorithm id, service reference, etc.)
+
+Staying with the REST/LDP theme, the available compatibility model containers could themselves be enumerated in an LDP container linked from the compatibility service "API home" URI.  Or maybe this container is the primary representation of the service?
+
+I've considered here the response to a match being one match-per-annotation, which means the set of candidates would itself be a collection of some kind (an annoation container?).  An alternaive might be multipk,e matches per anotation, but I feel it would be harder to leverage existing standards (e.g,. LDP, OA) for that.
+
+This interface does not constrain how the service is implemented: your suggestion of linking fragments througn a shared concept could be an implementation and storage strategy, with the service retrieving appropriate stored responses for any given request.  I do think it's important to have a uniform access interface for the remixer to access the compatibility service so that new models can be introduced without having to update the remixer code.
+
+((GK: These are just my initial thoughts; if you have different ideas, or see proiblems, please express them so I can respond - I think we need to converge on some implementable ideas very quickly.))
+
+((GK: as you indicate, I think we also need to consider the context within which the compatibility service operates, and in particular how it knows about fragments to be considered.  The current architecture diagram suggests to me that a working set is built from the outputs of a single NiN instance.  But I think it would be a small step to have possibly more than one instance of NiN contributing, or a single instance feeding multiple working sets.  Then, per the current archiutecture duagram, there are two kinds of working set: one generated by NiN outputs, and another constructed using the remixer.  As these are just(?) collections iof fragments, maybe these can be unified?))
+
+----
 
 Working sets:
   A set of fragments used in a Remixer session
@@ -26,15 +87,34 @@ Working sets:
     can we include by reference the previously defined containers
     (do these change over time?)
 
+((GK: LDP container here sounds handy: it would be good to have some idea of the representation used, but maybe this isn't so critical as (I think) it's internal to the remixer (i.e. not shared with other apps).  It might be handy if the same format used for incoming fragments can be used - only one thing to design!)
+
+----
+
 Assembled score
   Can use the Segment ontology to map the use of fragments in the composition?
   [Segment Ontology not currently online at: https://www.linkedmusic.org/ontologies]
 
-Output DMO
-  Similar Provenance information to the input DMOs
-    human decisions in creating the composition
-    also capture the working sets under consideration
-  Reference created MEI of the whole output
-    and also input fragments used
-    (the assembled score information)
+((GK: Segment Ontology (SO) sounds good - I think this aligns with the Jam session ideas.  I think we need a more complete view of how the bits fit together - I suspect a little more than SO will be needed.))
+
+----
+
+## Output DMO
+ 
+- Similar Provenance information to the input DMOs
+    - human decisions in creating the composition
+    - also capture the working sets under consideration
+- Reference created MEI of the whole output
+    - and also input fragments used
+    - (the assembled score information)
+
+((GK: I'm not sure what you mean here by "Similar Provenance information to the input DMOs".  Sure, also use PROV. But the processes being described are, I think, a bit different.  I would expect the DMO output to incorporate (or reference) provenance from the fragments used.))
+
+((GK: I think next step here is to add a diagram and/or example that shows how the vocab parts fit together.  I would recommend keeping a little separatiion between the provenance and the content - e.g. don't just lump it all into a single graph))
+
+----
+
+((GK: I've just noticed in the archiecture diagram that you have provenance capture as a separate activity, presented as something like a common service for NiN and the remixer.  I'm not sure this is helpful.  I had assumed that NiN output provenance would be generated by NiN part of the output fragment.  I understood the original provenance capture to be specific to be the remixer, effectively being a record of what happened in what might be considered as a MELD "session".  As such, I would expect the provenance in the output "DMO" to be provided via the remixer export.  The concern I have is that if it's a separate service, it adds another layer of interface to be considered, and could make it harder to scale up as there are more visible moving parts to be coordinated.))
+
+((GK: I'm thinking the notion of a NiN working set should be developed and unified, incorporating fragment media, descriptions, provenance and assembly (where available).  This would mean that the interface between NiN and the remixer, the remixer work-in-progress, and the final output could all be supported by a common desgn and interface service.  It would also mean that remixer outputs, possibly combined with additional NiN activities, could be used as input to subsequent remixer sessions.))
 


### PR DESCRIPTION
John: there are a few edits and a lot of commentary suggested here.

If you're agreeable, my final comment suggests a focused way forward, which is to define a unified workset representation that can be used as a general exchange format as:

- output from NiN
- input to the compatibility service
- input to the remixer
- output from the remixer

This would require some adjustments to the overall architecture, but i think the result could be easier to implement.  

I think there's still a lot of thinking about the compatibility service to consider, but hopefully not too much to get some kind of interface.  (Maybe a working set model could be used here, too? - but I'd be wary of over-stretching the idea.)